### PR TITLE
Update PricingComparison CSS layout and spacing

### DIFF
--- a/src/pages/PricingComparison.css
+++ b/src/pages/PricingComparison.css
@@ -38,7 +38,6 @@
 .header-content {
   align-self: end;
   display: flex;
-  margin-top: 89px;
   padding: 19px 17px 31px;
   flex-direction: column;
   align-items: stretch;
@@ -66,7 +65,6 @@
 .pricing-cards {
   display: flex;
   gap: -48px;
-  margin-bottom: 40px;
 }
 
 .pricing-card {
@@ -223,7 +221,7 @@
   align-items: center;
   gap: 20px;
   font-size: 16px;
-  padding: 20px 0;
+  padding-left: 20px;
   border-bottom: 1px solid rgba(240, 243, 247, 1);
 }
 
@@ -247,6 +245,7 @@
 
 .feature-value {
   min-width: 100px;
+  width: 100%;
   text-align: center;
 }
 
@@ -254,6 +253,7 @@
   background-color: rgba(250, 251, 252, 1);
   padding: 21px;
   border-radius: 4px;
+  width: 100%;
 }
 
 /* Tablet Styles */
@@ -274,7 +274,7 @@
   }
 
   .plan-labels {
-    gap: 70px;
+    gap: 100px;
   }
 
   .feature-values {

--- a/src/pages/PricingComparison.css
+++ b/src/pages/PricingComparison.css
@@ -64,7 +64,6 @@
 /* Pricing Cards */
 .pricing-cards {
   display: flex;
-  gap: -48px;
 }
 
 .pricing-card {
@@ -181,7 +180,6 @@
   background-color: rgba(248, 250, 252, 1);
   display: flex;
   width: 100%;
-  padding: 24px 32px 24px 27px;
   align-items: center;
   gap: 20px;
   font-size: 18px;
@@ -274,7 +272,7 @@
   }
 
   .plan-labels {
-    gap: 100px;
+    gap: 120px;
   }
 
   .feature-values {


### PR DESCRIPTION
Updates CSS styling for the PricingComparison component:

- Remove top margin from header-content class
- Remove bottom margin from pricing-cards class  
- Change feature-row padding from vertical to left-only
- Add full width to feature-value and feature-description classes
- Increase plan-labels gap from 70px to 100px on tablet view

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2d74bef66a6a40b1b7a36d385d0d47d7/neon-den)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2d74bef66a6a40b1b7a36d385d0d47d7</projectId>-->
<!--<branchName>neon-den</branchName>-->