### PR TITLE
Add mobile expandable cards to pricing component

### DIFF
--- a/src/pages/Example.jsx
+++ b/src/pages/Example.jsx
@@ -2,176 +2,129 @@ import React from "react";
 import "./PricingComparison.css";
 
 export default function Example() {
+  const plans = [
+    {
+      id: 1,
+      level: "Level 1",
+      type: "Basic plan",
+      price: "$10.00/month",
+      description:
+        "Perfect for small projects, personal websites, and development environments",
+      features: [
+        "vCPU: 16",
+        "RAM: 32 GB",
+        "Storage: 10 GB",
+        "Transfer: Unlimited",
+        "Anti-DDoS: Free",
+        "Database Options: MySQL ,MongoDB",
+      ],
+      showDetails: true,
+      buttonText: "Choose plan",
+      buttonType: "primary",
+    },
+    {
+      id: 2,
+      level: "Level 2",
+      type: "Pro plan",
+      price: "$15.00/month",
+      showDetails: false,
+      buttonType: "dropdown",
+    },
+    {
+      id: 3,
+      level: "Level 3",
+      type: "Enterprise plan",
+      price: "$20.00/month",
+      showDetails: false,
+      buttonType: "dropdown",
+    },
+    {
+      id: 4,
+      level: "Level 4",
+      type: "Enterprise plan",
+      price: "$25.00/month",
+      showDetails: false,
+      buttonType: "dropdown",
+    },
+    {
+      id: 5,
+      level: "Level 5",
+      type: "Enterprise plan",
+      price: "$30.00/month",
+      showDetails: false,
+      buttonType: "dropdown",
+    },
+  ];
+
   return (
-    <div className="pricing-container">
-      <div className="pricing-card-wrapper">
-        {/* Header Section */}
-        <div className="header-section">
-          <div className="header-content">
-            <h1 className="main-title">Detailed Feature Comparison</h1>
-            <p className="main-description">
-              Compare all features across our hosting plans
-            </p>
-          </div>
-
-          {/* Pricing Cards */}
-          <div className="pricing-cards">
-            {/* Startup VPS Card */}
-            <div className="pricing-card">
-              <h3 className="plan-name">STARTUP VPS</h3>
-              <div className="price-container">
-                <span className="price-amount">$7.78</span>
-                <span className="price-suffix">/month</span>
+    <div className="mobile-pricing-container">
+      {plans.map((plan) => (
+        <div
+          key={plan.id}
+          className={`mobile-pricing-card ${plan.showDetails ? "detailed" : "compact"}`}
+        >
+          <div className="plan-header">
+            <div className="plan-info-section">
+              <div className="plan-icon">
+                <img
+                  src="https://cdn.builder.io/api/v1/image/assets/3b078e06f1464ed6882e255b1243da7b/505a9ecc43bfc66faa92014d5f80144739da447f?placeholderIfAbsent=true"
+                  alt={`${plan.level} icon`}
+                  className="level-icon"
+                />
               </div>
-              <p className="plan-description">
-                Perfect for small projects and testing
-              </p>
-              <button className="plan-button inactive">Upgraded plan</button>
+              <div className="plan-details">
+                <h3 className="plan-level">{plan.level}</h3>
+                <p className="plan-type">{plan.type}</p>
+              </div>
             </div>
-
-            {/* Challenger VPS Card */}
-            <div className="pricing-card">
-              <h3 className="plan-name">CHALLENGER VPS</h3>
-              <div className="price-container">
-                <span className="price-amount">$13.78</span>
-                <span className="price-suffix">/month</span>
-              </div>
-              <p className="plan-description">
-                Ideal for growing businesses and applications
-              </p>
-              <button className="plan-button inactive">Upgraded plan</button>
-            </div>
-
-            {/* Leader VPS Card - Active Plan */}
-            <div className="pricing-card highlighted">
-              <h3 className="plan-name">LEADER VPS</h3>
-              <div className="price-container">
-                <span className="price-amount">$16.78</span>
-                <span className="price-suffix">/month</span>
-              </div>
-              <p className="plan-description">
-                Maximum performance for demanding workloads
-              </p>
-              <button className="plan-button active">
-                <svg
-                  className="checkmark-icon"
-                  width="24"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  fill="none"
+            <div className="plan-pricing">
+              <span className="plan-price">{plan.price}</span>
+              {plan.buttonType === "dropdown" && (
+                <button
+                  className="dropdown-toggle"
+                  aria-label="View plan details"
                 >
-                  <circle cx="12" cy="12" r="12" fill="currentColor" />
-                  <path
-                    d="M9 12l2 2 4-4"
-                    stroke="white"
-                    strokeWidth="2"
-                    fill="none"
-                  />
-                </svg>
-                Your plan
-              </button>
-            </div>
-
-            {/* Boss VPS Card */}
-            <div className="pricing-card">
-              <h3 className="plan-name">BOSS VPS</h3>
-              <div className="price-container">
-                <span className="price-amount">$25.78</span>
-                <span className="price-suffix">/month</span>
-              </div>
-              <p className="plan-description">Good for enterprise company</p>
-              <button className="plan-button primary">upgrade plan</button>
+                  <svg width="17" height="14" viewBox="0 0 17 14" fill="none">
+                    <path d="M8.5 14L0 0H17L8.5 14Z" fill="currentColor" />
+                  </svg>
+                </button>
+              )}
             </div>
           </div>
+
+          {plan.showDetails && (
+            <>
+              <p className="plan-description">{plan.description}</p>
+
+              <div className="features-list">
+                {plan.features.map((feature, index) => (
+                  <div key={index} className="feature-item">
+                    <div className="feature-checkmark">
+                      <svg
+                        width="20"
+                        height="20"
+                        viewBox="0 0 20 20"
+                        fill="none"
+                      >
+                        <circle cx="10" cy="10" r="10" fill="#10B981" />
+                        <path
+                          d="M6 10l2 2 6-6"
+                          stroke="white"
+                          strokeWidth="2"
+                          fill="none"
+                        />
+                      </svg>
+                    </div>
+                    <span className="feature-text">{feature}</span>
+                  </div>
+                ))}
+              </div>
+
+              <button className="choose-plan-button">{plan.buttonText}</button>
+            </>
+          )}
         </div>
-
-        {/* Feature Comparison Table */}
-        <div className="feature-table">
-          {/* Table Header */}
-          <div className="table-header">
-            <div className="feature-label">Features</div>
-            <div className="plan-labels">
-              <div className="plan-label">STARTUP</div>
-              <div className="plan-label highlighted-label">CHALLENGER</div>
-              <div className="plan-label">LEADER</div>
-              <div className="plan-label highlighted-label">BOSS</div>
-            </div>
-          </div>
-
-          {/* Feature Rows */}
-          <div className="feature-rows">
-            <div className="feature-row">
-              <div className="feature-name">vCPU Cores</div>
-              <div className="feature-values">
-                <div className="feature-value">1 Core</div>
-                <div className="feature-value highlighted-value">2 Cores</div>
-                <div className="feature-value">4 Cores</div>
-                <div className="feature-value highlighted-value">2 Cores</div>
-              </div>
-            </div>
-
-            <div className="feature-row">
-              <div className="feature-name">RAM Memory</div>
-              <div className="feature-values">
-                <div className="feature-value">2 GB</div>
-                <div className="feature-value highlighted-value">4 GB</div>
-                <div className="feature-value">8 GB</div>
-                <div className="feature-value highlighted-value">4 GB</div>
-              </div>
-            </div>
-
-            <div className="feature-row">
-              <div className="feature-name">Storage</div>
-              <div className="feature-values">
-                <div className="feature-value">25 GB</div>
-                <div className="feature-value highlighted-value">80 GB</div>
-                <div className="feature-value">160 GB</div>
-                <div className="feature-value highlighted-value">80 GB</div>
-              </div>
-            </div>
-
-            <div className="feature-row">
-              <div className="feature-name">Bandwidth</div>
-              <div className="feature-values">
-                <div className="feature-value">1 Gbps</div>
-                <div className="feature-value highlighted-value">1 Gbps</div>
-                <div className="feature-value">1 Gbps</div>
-                <div className="feature-value highlighted-value">1 Gbps</div>
-              </div>
-            </div>
-
-            <div className="feature-row">
-              <div className="feature-name">Transfer</div>
-              <div className="feature-values">
-                <div className="feature-value">Unlimited</div>
-                <div className="feature-value highlighted-value">Unlimited</div>
-                <div className="feature-value">Unlimited</div>
-                <div className="feature-value highlighted-value">Unlimited</div>
-              </div>
-            </div>
-
-            <div className="feature-row">
-              <div className="feature-name">Hard Drive</div>
-              <div className="feature-values">
-                <div className="feature-value">NVMe</div>
-                <div className="feature-value highlighted-value">NVMe</div>
-                <div className="feature-value">NVMe</div>
-                <div className="feature-value highlighted-value">NVMe</div>
-              </div>
-            </div>
-
-            <div className="feature-row">
-              <div className="feature-name">Anti-DDoS</div>
-              <div className="feature-values">
-                <div className="feature-value">Free</div>
-                <div className="feature-value highlighted-value">Free</div>
-                <div className="feature-value">Free</div>
-                <div className="feature-value highlighted-value">Free</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
+      ))}
     </div>
   );
 }

--- a/src/pages/Example.jsx
+++ b/src/pages/Example.jsx
@@ -10,14 +10,14 @@ export default function Example() {
       price: "$10.00/month",
       description:
         "Perfect for small projects, personal websites, and development environments",
-      features: [
-        "vCPU: 16",
-        "RAM: 32 GB",
-        "Storage: 10 GB",
-        "Transfer: Unlimited",
-        "Anti-DDoS: Free",
-        "Database Options: MySQL ,MongoDB",
-      ],
+      features: {
+        vCPU: "16",
+        RAM: "32 GB",
+        Storage: "10 GB",
+        Transfer: "Unlimited",
+        "Anti-DDoS": "Free",
+        "Database Options": "MySQL, MongoDB",
+      },
       showDetails: true,
       buttonText: "Choose plan",
       buttonType: "primary",
@@ -27,6 +27,14 @@ export default function Example() {
       level: "Level 2",
       type: "Pro plan",
       price: "$15.00/month",
+      features: {
+        vCPU: "32",
+        RAM: "64 GB",
+        Storage: "50 GB",
+        Transfer: "Unlimited",
+        "Anti-DDoS": "Free",
+        "Database Options": "MySQL, MongoDB, PostgreSQL",
+      },
       showDetails: false,
       buttonType: "dropdown",
     },
@@ -35,6 +43,14 @@ export default function Example() {
       level: "Level 3",
       type: "Enterprise plan",
       price: "$20.00/month",
+      features: {
+        vCPU: "64",
+        RAM: "128 GB",
+        Storage: "100 GB",
+        Transfer: "Unlimited",
+        "Anti-DDoS": "Premium",
+        "Database Options": "All databases + Redis",
+      },
       showDetails: false,
       buttonType: "dropdown",
     },
@@ -43,6 +59,14 @@ export default function Example() {
       level: "Level 4",
       type: "Enterprise plan",
       price: "$25.00/month",
+      features: {
+        vCPU: "128",
+        RAM: "256 GB",
+        Storage: "500 GB",
+        Transfer: "Unlimited",
+        "Anti-DDoS": "Premium",
+        "Database Options": "All databases + Dedicated",
+      },
       showDetails: false,
       buttonType: "dropdown",
     },
@@ -51,10 +75,20 @@ export default function Example() {
       level: "Level 5",
       type: "Enterprise plan",
       price: "$30.00/month",
+      features: {
+        vCPU: "256",
+        RAM: "512 GB",
+        Storage: "1 TB",
+        Transfer: "Unlimited",
+        "Anti-DDoS": "Enterprise",
+        "Database Options": "Custom solutions",
+      },
       showDetails: false,
       buttonType: "dropdown",
     },
   ];
+
+  const featureKeys = Object.keys(plans[0].features);
 
   return (
     <div className="mobile-pricing-container">

--- a/src/pages/Example.jsx
+++ b/src/pages/Example.jsx
@@ -1,7 +1,16 @@
-import React from "react";
+import React, { useState } from "react";
 import "./PricingComparison.css";
 
 export default function Example() {
+  const [expandedCards, setExpandedCards] = useState({ 1: true }); // Level 1 expanded by default
+
+  const toggleCard = (cardId) => {
+    setExpandedCards((prev) => ({
+      ...prev,
+      [cardId]: !prev[cardId],
+    }));
+  };
+
   const plans = [
     {
       id: 1,
@@ -18,7 +27,6 @@ export default function Example() {
         "Anti-DDoS": "Free",
         "Database Options": "MySQL, MongoDB",
       },
-      showDetails: true,
       buttonText: "Choose plan",
       buttonType: "primary",
     },
@@ -35,8 +43,8 @@ export default function Example() {
         "Anti-DDoS": "Free",
         "Database Options": "MySQL, MongoDB, PostgreSQL",
       },
-      showDetails: false,
-      buttonType: "dropdown",
+      buttonText: "Choose plan",
+      buttonType: "secondary",
     },
     {
       id: 3,
@@ -51,8 +59,8 @@ export default function Example() {
         "Anti-DDoS": "Premium",
         "Database Options": "All databases + Redis",
       },
-      showDetails: false,
-      buttonType: "dropdown",
+      buttonText: "Choose plan",
+      buttonType: "secondary",
     },
     {
       id: 4,
@@ -67,8 +75,8 @@ export default function Example() {
         "Anti-DDoS": "Premium",
         "Database Options": "All databases + Dedicated",
       },
-      showDetails: false,
-      buttonType: "dropdown",
+      buttonText: "Choose plan",
+      buttonType: "secondary",
     },
     {
       id: 5,
@@ -83,8 +91,8 @@ export default function Example() {
         "Anti-DDoS": "Enterprise",
         "Database Options": "Custom solutions",
       },
-      showDetails: false,
-      buttonType: "dropdown",
+      buttonText: "Choose plan",
+      buttonType: "secondary",
     },
   ];
 

--- a/src/pages/Example.jsx
+++ b/src/pages/Example.jsx
@@ -99,135 +99,252 @@ export default function Example() {
   const featureKeys = Object.keys(plans[0].features);
 
   return (
-    <div className="pricing-wrapper">
-      {/* Mobile Card Layout */}
-      <div className="mobile-pricing-container">
+    <div className="pricing-container">
+      <div className="pricing-card-wrapper">
+        {/* Header Section */}
+        <div className="header-section">
+          <div className="header-content">
+            <h1 className="main-title">Detailed Feature Comparison</h1>
+            <p className="main-description">
+              Compare all features across our hosting plans
+            </p>
+          </div>
+
+          {/* Pricing Cards */}
+          <div className="pricing-cards">
+            {/* Startup VPS Card */}
+            <div className="pricing-card">
+              <h3 className="plan-name">STARTUP VPS</h3>
+              <div className="price-container">
+                <span className="price-amount">$7.78</span>
+                <span className="price-suffix">/month</span>
+              </div>
+              <p className="plan-description">
+                Perfect for small projects and testing
+              </p>
+              <button className="plan-button inactive">Upgraded plan</button>
+            </div>
+
+            {/* Challenger VPS Card */}
+            <div className="pricing-card">
+              <h3 className="plan-name">CHALLENGER VPS</h3>
+              <div className="price-container">
+                <span className="price-amount">$13.78</span>
+                <span className="price-suffix">/month</span>
+              </div>
+              <p className="plan-description">
+                Ideal for growing businesses and applications
+              </p>
+              <button className="plan-button inactive">Upgraded plan</button>
+            </div>
+
+            {/* Leader VPS Card - Active Plan */}
+            <div className="pricing-card highlighted">
+              <h3 className="plan-name">LEADER VPS</h3>
+              <div className="price-container">
+                <span className="price-amount">$16.78</span>
+                <span className="price-suffix">/month</span>
+              </div>
+              <p className="plan-description">
+                Maximum performance for demanding workloads
+              </p>
+              <button className="plan-button active">
+                <svg
+                  className="checkmark-icon"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                >
+                  <circle cx="12" cy="12" r="12" fill="currentColor" />
+                  <path
+                    d="M9 12l2 2 4-4"
+                    stroke="white"
+                    strokeWidth="2"
+                    fill="none"
+                  />
+                </svg>
+                Your plan
+              </button>
+            </div>
+
+            {/* Boss VPS Card */}
+            <div className="pricing-card">
+              <h3 className="plan-name">BOSS VPS</h3>
+              <div className="price-container">
+                <span className="price-amount">$25.78</span>
+                <span className="price-suffix">/month</span>
+              </div>
+              <p className="plan-description">Good for enterprise company</p>
+              <button className="plan-button primary">upgrade plan</button>
+            </div>
+          </div>
+        </div>
+
+        {/* Feature Comparison Table */}
+        <div className="feature-table">
+          {/* Table Header */}
+          <div className="table-header">
+            <div className="feature-label">Features</div>
+            <div className="plan-labels">
+              <div className="plan-label">STARTUP</div>
+              <div className="plan-label highlighted-label">CHALLENGER</div>
+              <div className="plan-label">LEADER</div>
+              <div className="plan-label highlighted-label">BOSS</div>
+            </div>
+          </div>
+
+          {/* Feature Rows */}
+          <div className="feature-rows">
+            <div className="feature-row">
+              <div className="feature-name">vCPU Cores</div>
+              <div className="feature-values">
+                <div className="feature-value">1 Core</div>
+                <div className="feature-value highlighted-value">2 Cores</div>
+                <div className="feature-value">4 Cores</div>
+                <div className="feature-value highlighted-value">2 Cores</div>
+              </div>
+            </div>
+
+            <div className="feature-row">
+              <div className="feature-name">RAM Memory</div>
+              <div className="feature-values">
+                <div className="feature-value">2 GB</div>
+                <div className="feature-value highlighted-value">4 GB</div>
+                <div className="feature-value">8 GB</div>
+                <div className="feature-value highlighted-value">4 GB</div>
+              </div>
+            </div>
+
+            <div className="feature-row">
+              <div className="feature-name">Storage</div>
+              <div className="feature-values">
+                <div className="feature-value">25 GB</div>
+                <div className="feature-value highlighted-value">80 GB</div>
+                <div className="feature-value">160 GB</div>
+                <div className="feature-value highlighted-value">80 GB</div>
+              </div>
+            </div>
+
+            <div className="feature-row">
+              <div className="feature-name">Bandwidth</div>
+              <div className="feature-values">
+                <div className="feature-value">1 Gbps</div>
+                <div className="feature-value highlighted-value">1 Gbps</div>
+                <div className="feature-value">1 Gbps</div>
+                <div className="feature-value highlighted-value">1 Gbps</div>
+              </div>
+            </div>
+
+            <div className="feature-row">
+              <div className="feature-name">Transfer</div>
+              <div className="feature-values">
+                <div className="feature-value">Unlimited</div>
+                <div className="feature-value highlighted-value">Unlimited</div>
+                <div className="feature-value">Unlimited</div>
+                <div className="feature-value highlighted-value">Unlimited</div>
+              </div>
+            </div>
+
+            <div className="feature-row">
+              <div className="feature-name">Hard Drive</div>
+              <div className="feature-values">
+                <div className="feature-value">NVMe</div>
+                <div className="feature-value highlighted-value">NVMe</div>
+                <div className="feature-value">NVMe</div>
+                <div className="feature-value highlighted-value">NVMe</div>
+              </div>
+            </div>
+
+            <div className="feature-row">
+              <div className="feature-name">Anti-DDoS</div>
+              <div className="feature-values">
+                <div className="feature-value">Free</div>
+                <div className="feature-value highlighted-value">Free</div>
+                <div className="feature-value">Free</div>
+                <div className="feature-value highlighted-value">Free</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile Expandable Cards */}
+      <div className="mobile-cards-container">
         {plans.map((plan) => (
-          <div
-            key={plan.id}
-            className={`mobile-pricing-card ${plan.showDetails ? "detailed" : "compact"}`}
-          >
-            <div className="plan-header">
-              <div className="plan-info-section">
-                <div className="plan-icon">
+          <div key={plan.id} className="expandable-card">
+            <div className="card-header" onClick={() => toggleCard(plan.id)}>
+              <div className="card-info-section">
+                <div className="card-icon">
                   <img
                     src="https://cdn.builder.io/api/v1/image/assets/3b078e06f1464ed6882e255b1243da7b/505a9ecc43bfc66faa92014d5f80144739da447f?placeholderIfAbsent=true"
                     alt={`${plan.level} icon`}
                     className="level-icon"
                   />
                 </div>
-                <div className="plan-details">
-                  <h3 className="plan-level">{plan.level}</h3>
-                  <p className="plan-type">{plan.type}</p>
+                <div className="card-details">
+                  <h3 className="card-level">{plan.level}</h3>
+                  <p className="card-type">{plan.type}</p>
                 </div>
               </div>
-              <div className="plan-pricing">
-                <span className="plan-price">{plan.price}</span>
-                {plan.buttonType === "dropdown" && (
-                  <button
-                    className="dropdown-toggle"
-                    aria-label="View plan details"
+              <div className="card-pricing">
+                <span className="card-price">{plan.price}</span>
+                <button
+                  className="expand-toggle"
+                  aria-label="Toggle plan details"
+                >
+                  <svg
+                    width="17"
+                    height="14"
+                    viewBox="0 0 17 14"
+                    fill="none"
+                    className={expandedCards[plan.id] ? "rotated" : ""}
                   >
-                    <svg width="17" height="14" viewBox="0 0 17 14" fill="none">
-                      <path d="M8.5 14L0 0H17L8.5 14Z" fill="currentColor" />
-                    </svg>
-                  </button>
-                )}
+                    <path d="M8.5 14L0 0H17L8.5 14Z" fill="currentColor" />
+                  </svg>
+                </button>
               </div>
             </div>
 
-            {plan.showDetails && (
-              <>
-                <p className="plan-description">{plan.description}</p>
+            <div
+              className={`card-content ${expandedCards[plan.id] ? "expanded" : ""}`}
+            >
+              {plan.description && (
+                <p className="card-description">{plan.description}</p>
+              )}
 
-                <div className="features-list">
-                  {Object.entries(plan.features).map(([key, value], index) => (
-                    <div key={index} className="feature-item">
-                      <div className="feature-checkmark">
-                        <svg
-                          width="20"
-                          height="20"
-                          viewBox="0 0 20 20"
+              <div className="card-features-list">
+                {Object.entries(plan.features).map(([key, value], index) => (
+                  <div key={index} className="card-feature-item">
+                    <div className="card-feature-checkmark">
+                      <svg
+                        width="20"
+                        height="20"
+                        viewBox="0 0 20 20"
+                        fill="none"
+                      >
+                        <circle cx="10" cy="10" r="10" fill="#10B981" />
+                        <path
+                          d="M6 10l2 2 6-6"
+                          stroke="white"
+                          strokeWidth="2"
                           fill="none"
-                        >
-                          <circle cx="10" cy="10" r="10" fill="#10B981" />
-                          <path
-                            d="M6 10l2 2 6-6"
-                            stroke="white"
-                            strokeWidth="2"
-                            fill="none"
-                          />
-                        </svg>
-                      </div>
-                      <span className="feature-text">
-                        {key}: {value}
-                      </span>
+                        />
+                      </svg>
                     </div>
-                  ))}
-                </div>
+                    <span className="card-feature-text">
+                      {key}: {value}
+                    </span>
+                  </div>
+                ))}
+              </div>
 
-                <button className="choose-plan-button">
-                  {plan.buttonText}
-                </button>
-              </>
-            )}
+              <button className={`card-action-button ${plan.buttonType}`}>
+                {plan.buttonText}
+              </button>
+            </div>
           </div>
         ))}
-      </div>
-
-      {/* Desktop Table Layout */}
-      <div className="desktop-table-container">
-        <div className="table-wrapper">
-          <table className="pricing-table">
-            <thead>
-              <tr>
-                <th className="feature-header">Features</th>
-                {plans.map((plan) => (
-                  <th key={plan.id} className="plan-header-cell">
-                    <div className="plan-header-content">
-                      <div className="table-plan-icon">
-                        <img
-                          src="https://cdn.builder.io/api/v1/image/assets/3b078e06f1464ed6882e255b1243da7b/505a9ecc43bfc66faa92014d5f80144739da447f?placeholderIfAbsent=true"
-                          alt={`${plan.level} icon`}
-                          className="table-level-icon"
-                        />
-                      </div>
-                      <div className="table-plan-info">
-                        <h3 className="table-plan-level">{plan.level}</h3>
-                        <p className="table-plan-type">{plan.type}</p>
-                        <p className="table-plan-price">{plan.price}</p>
-                      </div>
-                    </div>
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {featureKeys.map((featureKey) => (
-                <tr key={featureKey} className="feature-row">
-                  <td className="feature-name">{featureKey}</td>
-                  {plans.map((plan) => (
-                    <td key={plan.id} className="feature-value">
-                      {plan.features[featureKey]}
-                    </td>
-                  ))}
-                </tr>
-              ))}
-              <tr className="action-row">
-                <td className="feature-name">Action</td>
-                {plans.map((plan) => (
-                  <td key={plan.id} className="action-cell">
-                    <button
-                      className={`table-action-button ${plan.id === 1 ? "primary" : "secondary"}`}
-                    >
-                      {plan.id === 1 ? "Choose Plan" : "Select"}
-                    </button>
-                  </td>
-                ))}
-              </tr>
-            </tbody>
-          </table>
-        </div>
       </div>
     </div>
   );

--- a/src/pages/Example.jsx
+++ b/src/pages/Example.jsx
@@ -91,74 +91,136 @@ export default function Example() {
   const featureKeys = Object.keys(plans[0].features);
 
   return (
-    <div className="mobile-pricing-container">
-      {plans.map((plan) => (
-        <div
-          key={plan.id}
-          className={`mobile-pricing-card ${plan.showDetails ? "detailed" : "compact"}`}
-        >
-          <div className="plan-header">
-            <div className="plan-info-section">
-              <div className="plan-icon">
-                <img
-                  src="https://cdn.builder.io/api/v1/image/assets/3b078e06f1464ed6882e255b1243da7b/505a9ecc43bfc66faa92014d5f80144739da447f?placeholderIfAbsent=true"
-                  alt={`${plan.level} icon`}
-                  className="level-icon"
-                />
+    <div className="pricing-wrapper">
+      {/* Mobile Card Layout */}
+      <div className="mobile-pricing-container">
+        {plans.map((plan) => (
+          <div
+            key={plan.id}
+            className={`mobile-pricing-card ${plan.showDetails ? "detailed" : "compact"}`}
+          >
+            <div className="plan-header">
+              <div className="plan-info-section">
+                <div className="plan-icon">
+                  <img
+                    src="https://cdn.builder.io/api/v1/image/assets/3b078e06f1464ed6882e255b1243da7b/505a9ecc43bfc66faa92014d5f80144739da447f?placeholderIfAbsent=true"
+                    alt={`${plan.level} icon`}
+                    className="level-icon"
+                  />
+                </div>
+                <div className="plan-details">
+                  <h3 className="plan-level">{plan.level}</h3>
+                  <p className="plan-type">{plan.type}</p>
+                </div>
               </div>
-              <div className="plan-details">
-                <h3 className="plan-level">{plan.level}</h3>
-                <p className="plan-type">{plan.type}</p>
+              <div className="plan-pricing">
+                <span className="plan-price">{plan.price}</span>
+                {plan.buttonType === "dropdown" && (
+                  <button
+                    className="dropdown-toggle"
+                    aria-label="View plan details"
+                  >
+                    <svg width="17" height="14" viewBox="0 0 17 14" fill="none">
+                      <path d="M8.5 14L0 0H17L8.5 14Z" fill="currentColor" />
+                    </svg>
+                  </button>
+                )}
               </div>
             </div>
-            <div className="plan-pricing">
-              <span className="plan-price">{plan.price}</span>
-              {plan.buttonType === "dropdown" && (
-                <button
-                  className="dropdown-toggle"
-                  aria-label="View plan details"
-                >
-                  <svg width="17" height="14" viewBox="0 0 17 14" fill="none">
-                    <path d="M8.5 14L0 0H17L8.5 14Z" fill="currentColor" />
-                  </svg>
-                </button>
-              )}
-            </div>
-          </div>
 
-          {plan.showDetails && (
-            <>
-              <p className="plan-description">{plan.description}</p>
+            {plan.showDetails && (
+              <>
+                <p className="plan-description">{plan.description}</p>
 
-              <div className="features-list">
-                {plan.features.map((feature, index) => (
-                  <div key={index} className="feature-item">
-                    <div className="feature-checkmark">
-                      <svg
-                        width="20"
-                        height="20"
-                        viewBox="0 0 20 20"
-                        fill="none"
-                      >
-                        <circle cx="10" cy="10" r="10" fill="#10B981" />
-                        <path
-                          d="M6 10l2 2 6-6"
-                          stroke="white"
-                          strokeWidth="2"
+                <div className="features-list">
+                  {Object.entries(plan.features).map(([key, value], index) => (
+                    <div key={index} className="feature-item">
+                      <div className="feature-checkmark">
+                        <svg
+                          width="20"
+                          height="20"
+                          viewBox="0 0 20 20"
                           fill="none"
-                        />
-                      </svg>
+                        >
+                          <circle cx="10" cy="10" r="10" fill="#10B981" />
+                          <path
+                            d="M6 10l2 2 6-6"
+                            stroke="white"
+                            strokeWidth="2"
+                            fill="none"
+                          />
+                        </svg>
+                      </div>
+                      <span className="feature-text">
+                        {key}: {value}
+                      </span>
                     </div>
-                    <span className="feature-text">{feature}</span>
-                  </div>
-                ))}
-              </div>
+                  ))}
+                </div>
 
-              <button className="choose-plan-button">{plan.buttonText}</button>
-            </>
-          )}
+                <button className="choose-plan-button">
+                  {plan.buttonText}
+                </button>
+              </>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Desktop Table Layout */}
+      <div className="desktop-table-container">
+        <div className="table-wrapper">
+          <table className="pricing-table">
+            <thead>
+              <tr>
+                <th className="feature-header">Features</th>
+                {plans.map((plan) => (
+                  <th key={plan.id} className="plan-header-cell">
+                    <div className="plan-header-content">
+                      <div className="table-plan-icon">
+                        <img
+                          src="https://cdn.builder.io/api/v1/image/assets/3b078e06f1464ed6882e255b1243da7b/505a9ecc43bfc66faa92014d5f80144739da447f?placeholderIfAbsent=true"
+                          alt={`${plan.level} icon`}
+                          className="table-level-icon"
+                        />
+                      </div>
+                      <div className="table-plan-info">
+                        <h3 className="table-plan-level">{plan.level}</h3>
+                        <p className="table-plan-type">{plan.type}</p>
+                        <p className="table-plan-price">{plan.price}</p>
+                      </div>
+                    </div>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {featureKeys.map((featureKey) => (
+                <tr key={featureKey} className="feature-row">
+                  <td className="feature-name">{featureKey}</td>
+                  {plans.map((plan) => (
+                    <td key={plan.id} className="feature-value">
+                      {plan.features[featureKey]}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+              <tr className="action-row">
+                <td className="feature-name">Action</td>
+                {plans.map((plan) => (
+                  <td key={plan.id} className="action-cell">
+                    <button
+                      className={`table-action-button ${plan.id === 1 ? "primary" : "secondary"}`}
+                    >
+                      {plan.id === 1 ? "Choose Plan" : "Select"}
+                    </button>
+                  </td>
+                ))}
+              </tr>
+            </tbody>
+          </table>
         </div>
-      ))}
+      </div>
     </div>
   );
 }

--- a/src/pages/PricingComparison.css
+++ b/src/pages/PricingComparison.css
@@ -205,10 +205,15 @@
 
 .plan-label {
   min-width: 100px;
+  width: 100%;
+  flex-grow: 0;
+  padding: 24px 0;
 }
 
 .plan-label.highlighted-label {
-  padding: 24px 52px;
+  width: 100%;
+  flex-grow: 0;
+  padding: 24px 0;
 }
 
 .feature-rows {

--- a/src/pages/PricingComparison.css
+++ b/src/pages/PricingComparison.css
@@ -64,6 +64,7 @@
 /* Pricing Cards */
 .pricing-cards {
   display: flex;
+  width: 100%;
 }
 
 .pricing-card {

--- a/src/pages/PricingComparison.css
+++ b/src/pages/PricingComparison.css
@@ -481,7 +481,6 @@
   .pricing-cards {
     flex-direction: row;
     flex-wrap: wrap;
-    gap: 20px;
   }
 
   .pricing-card {

--- a/src/pages/PricingComparison.css
+++ b/src/pages/PricingComparison.css
@@ -236,6 +236,7 @@
   font-weight: 500;
   min-width: 120px;
   text-align: left;
+  flex-grow: 0;
 }
 
 .feature-values {

--- a/src/pages/PricingComparison.css
+++ b/src/pages/PricingComparison.css
@@ -1,5 +1,268 @@
-/* Mobile-first responsive design for pricing component */
-.pricing-wrapper {
+/* Mobile-first responsive design */
+.pricing-container {
+  display: flex;
+  padding-top: 87px;
+  flex-direction: column;
+  align-items: stretch;
+  font-family:
+    "Nunito Sans",
+    -apple-system,
+    "Roboto",
+    "Helvetica",
+    sans-serif;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.pricing-card-wrapper {
+  border-radius: 24px;
+  background-color: #ffffff;
+  box-shadow: 0px 10px 15px rgba(0, 0, 0, 0.1);
+  border: 1px solid rgba(226, 232, 240, 1);
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+/* Header Section */
+.header-section {
+  z-index: 10;
+  display: flex;
+  margin-top: -87px;
+  align-items: stretch;
+  width: auto;
+  align-self: center;
+}
+
+.header-content {
+  align-self: end;
+  display: flex;
+  padding: 19px 17px 31px;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.main-title {
+  color: rgba(15, 23, 42, 1);
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 32px;
+  margin-right: auto;
+  text-align: left;
+}
+
+.main-description {
+  color: rgba(100, 116, 139, 1);
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 24px;
+  margin: 9px auto 0 0;
+  text-align: left;
+}
+
+/* Pricing Cards */
+.pricing-cards {
+  display: flex;
+}
+
+.pricing-card {
+  border-radius: 12px;
+  background-color: #ffffff;
+  box-shadow: 0px 10px 15px rgba(0, 0, 0, 0.1);
+  border: 1px solid rgba(230, 233, 245, 1);
+  display: flex;
+  padding: 32px;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.pricing-card.highlighted {
+  border: 2px solid rgba(230, 233, 245, 1);
+  position: relative;
+}
+
+.plan-name {
+  color: rgba(37, 36, 48, 1);
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 42px;
+  margin: 0 0 10px;
+}
+
+.price-container {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 4px;
+  margin-bottom: 28px;
+}
+
+.price-amount {
+  color: rgba(37, 36, 48, 1);
+  font-size: 24px;
+  font-weight: 700;
+  line-height: 72px;
+}
+
+.price-suffix {
+  color: rgba(84, 95, 113, 1);
+  font-size: 18px;
+  font-weight: 400;
+  text-align: center;
+}
+
+.plan-description {
+  color: rgba(84, 95, 113, 1);
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 21px;
+  margin: 0 0 20px;
+}
+
+.plan-button {
+  border-radius: 8px;
+  box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.25);
+  display: flex;
+  min-height: 55px;
+  padding: 0 16px;
+  align-items: center;
+  gap: 8px;
+  font-family:
+    "Roboto",
+    -apple-system,
+    sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  text-transform: capitalize;
+  letter-spacing: 1.25px;
+  line-height: 36px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  width: 100%;
+  justify-content: center;
+}
+
+.plan-button.inactive {
+  background-color: rgba(214, 214, 214, 1);
+  color: #ffffff;
+}
+
+.plan-button.active {
+  background-color: rgba(7, 193, 96, 1);
+  color: #ffffff;
+}
+
+.plan-button.primary {
+  background-color: #1976d2;
+  color: #ffffff;
+}
+
+.plan-button:hover {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+.checkmark-icon {
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+}
+
+/* Feature Table */
+.feature-table {
+  width: 100%;
+}
+
+.table-header {
+  background-color: rgba(248, 250, 252, 1);
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 20px;
+  font-size: 18px;
+  color: rgba(15, 23, 42, 1);
+  font-weight: 700;
+  flex-wrap: wrap;
+}
+
+.feature-label {
+  margin-right: auto;
+}
+
+.plan-labels {
+  display: flex;
+  align-items: center;
+  gap: 40px;
+  text-align: center;
+  flex-wrap: wrap;
+}
+
+.plan-label {
+  min-width: 100px;
+}
+
+.plan-label.highlighted-label {
+  padding: 24px 52px;
+}
+
+.feature-rows {
+  display: flex;
+  flex-direction: column;
+}
+
+.feature-row {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 20px;
+  font-size: 16px;
+  padding-left: 20px;
+  border-bottom: 1px solid rgba(240, 243, 247, 1);
+}
+
+.feature-name {
+  color: rgba(55, 65, 81, 1);
+  font-weight: 500;
+  min-width: 120px;
+  text-align: left;
+}
+
+.feature-values {
+  display: flex;
+  align-items: center;
+  gap: 40px;
+  color: rgba(31, 41, 55, 1);
+  font-weight: 400;
+  text-align: center;
+  flex: 1;
+  justify-content: space-around;
+}
+
+.feature-value {
+  min-width: 100px;
+  width: 100%;
+  text-align: center;
+}
+
+.feature-value.highlighted-value {
+  background-color: rgba(250, 251, 252, 1);
+  padding: 21px;
+  border-radius: 4px;
+  width: 100%;
+}
+
+/* Mobile Expandable Cards */
+.mobile-cards-container {
+  display: none;
+  flex-direction: column;
+  max-width: 480px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 20px;
+  gap: 20px;
   font-family:
     "Inter",
     -apple-system,
@@ -8,22 +271,7 @@
     sans-serif;
 }
 
-.mobile-pricing-container {
-  display: flex;
-  flex-direction: column;
-  max-width: 480px;
-  width: 100%;
-  margin: 0 auto;
-  padding: 20px;
-  gap: 20px;
-}
-
-/* Hide desktop table on mobile/tablet */
-.desktop-table-container {
-  display: none;
-}
-
-.mobile-pricing-card {
+.expandable-card {
   background-color: #ffffff;
   border-radius: 16px;
   border: 1px solid #e2e8f0;
@@ -32,35 +280,28 @@
   transition: all 0.2s ease;
 }
 
-.mobile-pricing-card:hover {
+.expandable-card:hover {
   box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
   transform: translateY(-1px);
 }
 
-.mobile-pricing-card.detailed {
-  padding: 22px 18px;
-}
-
-.mobile-pricing-card.compact {
-  padding: 17px 23px;
-}
-
-.plan-header {
+.card-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  width: 100%;
-  gap: 40px;
+  padding: 17px 23px;
+  cursor: pointer;
+  user-select: none;
 }
 
-.plan-info-section {
+.card-info-section {
   display: flex;
   align-items: center;
   gap: 10px;
   flex: 1;
 }
 
-.plan-icon {
+.card-icon {
   display: flex;
   width: 48px;
   height: 48px;
@@ -73,13 +314,13 @@
   object-fit: contain;
 }
 
-.plan-details {
+.card-details {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
 }
 
-.plan-level {
+.card-level {
   color: #1f2937;
   font-size: 16px;
   font-weight: 600;
@@ -87,7 +328,7 @@
   margin: 0;
 }
 
-.plan-type {
+.card-type {
   color: #6b7280;
   font-size: 14px;
   font-weight: 500;
@@ -95,7 +336,7 @@
   margin: 0;
 }
 
-.plan-pricing {
+.card-pricing {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -103,7 +344,7 @@
   justify-content: flex-end;
 }
 
-.plan-price {
+.card-price {
   color: #1f2937;
   font-size: 16px;
   font-weight: 600;
@@ -111,7 +352,7 @@
   white-space: nowrap;
 }
 
-.dropdown-toggle {
+.expand-toggle {
   background: none;
   border: none;
   color: #6b7280;
@@ -119,19 +360,36 @@
   padding: 4px;
   display: flex;
   align-items: center;
-  transition: color 0.2s ease;
+  transition: all 0.2s ease;
 }
 
-.dropdown-toggle:hover {
+.expand-toggle:hover {
   color: #374151;
 }
 
-.dropdown-toggle svg {
+.expand-toggle svg {
   width: 17px;
   height: 14px;
+  transition: transform 0.2s ease;
 }
 
-.plan-description {
+.expand-toggle svg.rotated {
+  transform: rotate(180deg);
+}
+
+.card-content {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+  padding: 0 23px;
+}
+
+.card-content.expanded {
+  max-height: 1000px;
+  padding: 0 23px 23px;
+}
+
+.card-description {
   color: #64748b;
   font-size: 16px;
   font-weight: 400;
@@ -139,20 +397,20 @@
   margin: 17px 0 0 0;
 }
 
-.features-list {
+.card-features-list {
   display: flex;
   flex-direction: column;
   gap: 16px;
   margin-top: 19px;
 }
 
-.feature-item {
+.card-feature-item {
   display: flex;
   align-items: center;
   gap: 12px;
 }
 
-.feature-checkmark {
+.card-feature-checkmark {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -161,19 +419,19 @@
   flex-shrink: 0;
 }
 
-.feature-checkmark svg {
+.card-feature-checkmark svg {
   width: 20px;
   height: 20px;
 }
 
-.feature-text {
+.card-feature-text {
   color: #475569;
   font-size: 16px;
   font-weight: 400;
   line-height: 1.5;
 }
 
-.choose-plan-button {
+.card-action-button {
   background: var(--custom-primary, #1976d2);
   color: var(--shades-white, #fff);
   border: none;
@@ -200,296 +458,192 @@
   transition: all 0.2s ease;
 }
 
-.choose-plan-button:hover {
-  background: #1565c0;
+.card-action-button.secondary {
+  background: #e5e7eb;
+  color: #374151;
+}
+
+.card-action-button:hover {
   transform: translateY(-1px);
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.3);
 }
 
-.choose-plan-button:active {
-  transform: translateY(0);
-  box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.25);
+.card-action-button.primary:hover {
+  background: #1565c0;
+}
+
+.card-action-button.secondary:hover {
+  background: #d1d5db;
 }
 
 /* Tablet Styles */
 @media (min-width: 768px) {
-  .mobile-pricing-container {
+  .pricing-cards {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 20px;
+  }
+
+  .pricing-card {
+    flex: 1;
+    min-width: 200px;
+  }
+
+  .table-header {
+    justify-content: space-between;
+  }
+
+  .plan-labels {
+    gap: 120px;
+  }
+
+  .feature-values {
+    gap: 72px;
+  }
+
+  .mobile-cards-container {
     max-width: 600px;
     padding: 40px;
   }
 
-  .mobile-pricing-card.detailed {
-    padding: 32px 24px;
-  }
-
-  .mobile-pricing-card.compact {
+  .expandable-card .card-header {
     padding: 24px 32px;
   }
 
-  .plan-header {
-    gap: 60px;
+  .expandable-card .card-content.expanded {
+    padding: 0 32px 32px;
   }
 
-  .plan-level {
+  .card-level {
     font-size: 18px;
   }
 
-  .plan-type {
+  .card-type {
     font-size: 15px;
   }
 
-  .plan-price {
+  .card-price {
     font-size: 18px;
   }
 
-  .plan-description {
+  .card-description {
     font-size: 17px;
     line-height: 28px;
   }
 
-  .feature-text {
+  .card-feature-text {
     font-size: 17px;
   }
 }
 
-/* Desktop Styles */
+/* Desktop Styles - Show original table, hide mobile cards */
 @media (min-width: 1024px) {
-  /* Hide mobile cards on desktop */
-  .mobile-pricing-container {
-    display: none;
-  }
-
-  /* Show desktop table on desktop */
-  .desktop-table-container {
-    display: block;
-    padding: 40px;
-    max-width: 1400px;
+  .pricing-container {
+    max-width: 1200px;
     margin: 0 auto;
   }
 
-  .table-wrapper {
-    background-color: #ffffff;
-    border-radius: 16px;
-    border: 1px solid #e2e8f0;
-    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
-    overflow: hidden;
+  .pricing-cards {
+    flex-wrap: nowrap;
   }
 
-  .pricing-table {
-    width: 100%;
-    border-collapse: collapse;
-  }
-
-  .pricing-table th,
-  .pricing-table td {
-    padding: 20px;
-    text-align: center;
-    border-bottom: 1px solid #f1f5f9;
-  }
-
-  .pricing-table th {
-    background-color: #f8fafc;
-    font-weight: 600;
-    color: #1f2937;
-  }
-
-  .feature-header {
-    text-align: left;
-    font-size: 18px;
-    color: #374151;
-    min-width: 180px;
-  }
-
-  .plan-header-cell {
-    background-color: #f8fafc;
-    border-bottom: 2px solid #e2e8f0;
+  .pricing-card {
     min-width: 200px;
   }
 
-  .plan-header-content {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 12px;
+  .header-content {
+    padding: 19px 17px 31px;
   }
 
-  .table-plan-icon {
-    width: 48px;
-    height: 48px;
+  .main-title {
+    font-size: 28px;
+    line-height: 36px;
+    margin-right: auto;
+    text-align: left;
   }
 
-  .table-level-icon {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-  }
-
-  .table-plan-info {
-    text-align: center;
-  }
-
-  .table-plan-level {
+  .main-description {
     font-size: 18px;
-    font-weight: 600;
-    color: #1f2937;
-    margin: 0 0 4px 0;
-  }
-
-  .table-plan-type {
-    font-size: 14px;
-    color: #6b7280;
-    margin: 0 0 8px 0;
-  }
-
-  .table-plan-price {
-    font-size: 16px;
-    font-weight: 600;
-    color: #1f2937;
-    margin: 0;
-  }
-
-  .feature-row:nth-child(even) {
-    background-color: #f9fafb;
+    line-height: 28px;
+    margin: 9px auto 0 0;
+    text-align: left;
   }
 
   .feature-name {
-    text-align: left;
-    font-weight: 500;
-    color: #374151;
-    font-size: 16px;
+    min-width: 150px;
   }
 
-  .feature-value {
-    color: #1f2937;
-    font-size: 15px;
-    font-weight: 400;
-  }
-
-  .action-row {
-    background-color: #f8fafc;
-  }
-
-  .action-row .feature-name {
-    font-weight: 600;
-    color: #1f2937;
-  }
-
-  .action-cell {
-    padding: 24px 20px;
-  }
-
-  .table-action-button {
-    background: #e5e7eb;
-    color: #374151;
-    border: none;
-    border-radius: 8px;
-    padding: 12px 24px;
-    font-size: 14px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    min-width: 120px;
-  }
-
-  .table-action-button.primary {
-    background: #1976d2;
-    color: #ffffff;
-  }
-
-  .table-action-button:hover {
-    transform: translateY(-1px);
-    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
-  }
-
-  .table-action-button.primary:hover {
-    background: #1565c0;
-  }
-
-  .table-action-button.secondary:hover {
-    background: #d1d5db;
+  /* Hide mobile cards on desktop */
+  .mobile-cards-container {
+    display: none;
   }
 }
 
 /* Large Desktop */
 @media (min-width: 1280px) {
-  .desktop-table-container {
-    padding: 60px;
-    max-width: 1600px;
+  .pricing-container {
+    max-width: 1400px;
   }
 
-  .pricing-table th,
-  .pricing-table td {
-    padding: 24px;
+  .pricing-card {
+    padding: 40px;
   }
 
-  .table-plan-icon {
-    width: 56px;
-    height: 56px;
+  .feature-table {
+    max-width: 1102px;
+    align-self: end;
+  }
+}
+
+/* Mobile Responsive - Show cards, hide table */
+@media (max-width: 1023px) {
+  .pricing-card-wrapper {
+    display: none;
   }
 
-  .table-plan-level {
-    font-size: 20px;
-  }
-
-  .table-plan-type {
-    font-size: 15px;
-  }
-
-  .table-plan-price {
-    font-size: 18px;
-  }
-
-  .feature-name {
-    font-size: 17px;
-  }
-
-  .feature-value {
-    font-size: 16px;
-  }
-
-  .table-action-button {
-    padding: 14px 28px;
-    font-size: 15px;
-    min-width: 140px;
+  .mobile-cards-container {
+    display: flex;
   }
 }
 
 /* Accessibility improvements */
 @media (prefers-reduced-motion: reduce) {
-  .mobile-pricing-card,
-  .choose-plan-button,
-  .dropdown-toggle {
+  .expandable-card,
+  .card-action-button,
+  .expand-toggle svg,
+  .card-content {
     transition: none;
   }
 
-  .mobile-pricing-card:hover {
+  .expandable-card:hover {
     transform: none;
   }
 
-  .choose-plan-button:hover {
+  .card-action-button:hover {
     transform: none;
   }
 }
 
 /* Focus styles for keyboard navigation */
-.choose-plan-button:focus,
-.dropdown-toggle:focus {
+.card-action-button:focus,
+.expand-toggle:focus,
+.card-header:focus {
   outline: 2px solid #1976d2;
   outline-offset: 2px;
 }
 
 /* High contrast mode support */
 @media (prefers-contrast: high) {
-  .mobile-pricing-card {
+  .expandable-card {
     border-width: 2px;
   }
 
-  .feature-checkmark svg circle {
+  .card-feature-checkmark svg circle {
     fill: #000;
   }
 
-  .plan-description,
-  .feature-text {
+  .card-description,
+  .card-feature-text {
     color: #000;
   }
 }

--- a/src/pages/PricingComparison.css
+++ b/src/pages/PricingComparison.css
@@ -31,8 +31,8 @@
   display: flex;
   margin-top: -87px;
   align-items: stretch;
-  width: auto;
-  align-self: center;
+  width: 100%;
+  align-self: start;
 }
 
 .header-content {

--- a/src/pages/PricingComparison.css
+++ b/src/pages/PricingComparison.css
@@ -1,338 +1,370 @@
-/* Mobile-first responsive design */
-.pricing-container {
+/* Mobile-first responsive design for pricing component */
+.mobile-pricing-container {
   display: flex;
-  padding-top: 87px;
   flex-direction: column;
-  align-items: stretch;
+  max-width: 480px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 20px;
+  gap: 20px;
   font-family:
-    "Nunito Sans",
+    "Inter",
     -apple-system,
     "Roboto",
     "Helvetica",
     sans-serif;
-  max-width: 1200px;
-  margin: 0 auto;
 }
 
-.pricing-card-wrapper {
-  border-radius: 24px;
+.mobile-pricing-card {
   background-color: #ffffff;
-  box-shadow: 0px 10px 15px rgba(0, 0, 0, 0.1);
-  border: 1px solid rgba(226, 232, 240, 1);
-  display: flex;
-  width: 100%;
-  flex-direction: column;
-  align-items: stretch;
-}
-
-/* Header Section */
-.header-section {
-  z-index: 10;
-  display: flex;
-  margin-top: -87px;
-  align-items: stretch;
-  width: auto;
-  align-self: center;
-}
-
-.header-content {
-  align-self: end;
-  display: flex;
-  padding: 19px 17px 31px;
-  flex-direction: column;
-  align-items: stretch;
-}
-
-.main-title {
-  color: rgba(15, 23, 42, 1);
-  font-size: 24px;
-  font-weight: 700;
-  line-height: 32px;
-  margin-right: auto;
-  text-align: left;
-}
-
-.main-description {
-  color: rgba(100, 116, 139, 1);
-  font-size: 16px;
-  font-weight: 400;
-  line-height: 24px;
-  margin: 9px auto 0 0;
-  text-align: left;
-}
-
-/* Pricing Cards */
-.pricing-cards {
-  display: flex;
-}
-
-.pricing-card {
-  border-radius: 12px;
-  background-color: #ffffff;
-  box-shadow: 0px 10px 15px rgba(0, 0, 0, 0.1);
-  border: 1px solid rgba(230, 233, 245, 1);
-  display: flex;
-  padding: 32px;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-}
-
-.pricing-card.highlighted {
-  border: 2px solid rgba(230, 233, 245, 1);
-  position: relative;
-}
-
-.plan-name {
-  color: rgba(37, 36, 48, 1);
-  font-size: 16px;
-  font-weight: 700;
-  line-height: 42px;
-  margin: 0 0 10px;
-}
-
-.price-container {
-  display: flex;
-  align-items: baseline;
-  justify-content: center;
-  gap: 4px;
-  margin-bottom: 28px;
-}
-
-.price-amount {
-  color: rgba(37, 36, 48, 1);
-  font-size: 24px;
-  font-weight: 700;
-  line-height: 72px;
-}
-
-.price-suffix {
-  color: rgba(84, 95, 113, 1);
-  font-size: 18px;
-  font-weight: 400;
-  text-align: center;
-}
-
-.plan-description {
-  color: rgba(84, 95, 113, 1);
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 21px;
-  margin: 0 0 20px;
-}
-
-.plan-button {
-  border-radius: 8px;
-  box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.25);
-  display: flex;
-  min-height: 55px;
-  padding: 0 16px;
-  align-items: center;
-  gap: 8px;
-  font-family:
-    "Roboto",
-    -apple-system,
-    sans-serif;
-  font-size: 14px;
-  font-weight: 500;
-  text-transform: capitalize;
-  letter-spacing: 1.25px;
-  line-height: 36px;
-  border: none;
-  cursor: pointer;
+  border-radius: 16px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.06);
+  overflow: hidden;
   transition: all 0.2s ease;
-  width: 100%;
-  justify-content: center;
 }
 
-.plan-button.inactive {
-  background-color: rgba(214, 214, 214, 1);
-  color: #ffffff;
-}
-
-.plan-button.active {
-  background-color: rgba(7, 193, 96, 1);
-  color: #ffffff;
-}
-
-.plan-button.primary {
-  background-color: #1976d2;
-  color: #ffffff;
-}
-
-.plan-button:hover {
-  opacity: 0.9;
+.mobile-pricing-card:hover {
+  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
   transform: translateY(-1px);
 }
 
-.checkmark-icon {
-  width: 24px;
-  height: 24px;
+.mobile-pricing-card.detailed {
+  padding: 22px 18px;
+}
+
+.mobile-pricing-card.compact {
+  padding: 17px 23px;
+}
+
+.plan-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 40px;
+}
+
+.plan-info-section {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+}
+
+.plan-icon {
+  display: flex;
+  width: 48px;
+  height: 48px;
   flex-shrink: 0;
 }
 
-/* Feature Table */
-.feature-table {
+.level-icon {
   width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
-.table-header {
-  background-color: rgba(248, 250, 252, 1);
-  display: flex;
-  width: 100%;
-  align-items: center;
-  gap: 20px;
-  font-size: 18px;
-  color: rgba(15, 23, 42, 1);
-  font-weight: 700;
-  flex-wrap: wrap;
-}
-
-.feature-label {
-  margin-right: auto;
-}
-
-.plan-labels {
-  display: flex;
-  align-items: center;
-  gap: 40px;
-  text-align: center;
-  flex-wrap: wrap;
-}
-
-.plan-label {
-  min-width: 100px;
-}
-
-.plan-label.highlighted-label {
-  padding: 24px 52px;
-}
-
-.feature-rows {
+.plan-details {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
 }
 
-.feature-row {
-  display: flex;
-  width: 100%;
-  align-items: center;
-  gap: 20px;
+.plan-level {
+  color: #1f2937;
   font-size: 16px;
-  padding-left: 20px;
-  border-bottom: 1px solid rgba(240, 243, 247, 1);
+  font-weight: 600;
+  line-height: 1.25;
+  margin: 0;
 }
 
-.feature-name {
-  color: rgba(55, 65, 81, 1);
+.plan-type {
+  color: #6b7280;
+  font-size: 14px;
   font-weight: 500;
-  min-width: 120px;
-  text-align: left;
+  line-height: 1.29;
+  margin: 0;
 }
 
-.feature-values {
+.plan-pricing {
   display: flex;
   align-items: center;
-  gap: 40px;
-  color: rgba(31, 41, 55, 1);
-  font-weight: 400;
-  text-align: center;
+  gap: 6px;
   flex: 1;
-  justify-content: space-around;
+  justify-content: flex-end;
 }
 
-.feature-value {
-  min-width: 100px;
-  width: 100%;
-  text-align: center;
+.plan-price {
+  color: #1f2937;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.25;
+  white-space: nowrap;
 }
 
-.feature-value.highlighted-value {
-  background-color: rgba(250, 251, 252, 1);
-  padding: 21px;
-  border-radius: 4px;
+.dropdown-toggle {
+  background: none;
+  border: none;
+  color: #6b7280;
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  transition: color 0.2s ease;
+}
+
+.dropdown-toggle:hover {
+  color: #374151;
+}
+
+.dropdown-toggle svg {
+  width: 17px;
+  height: 14px;
+}
+
+.plan-description {
+  color: #64748b;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 26px;
+  margin: 17px 0 0 0;
+}
+
+.features-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-top: 19px;
+}
+
+.feature-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.feature-checkmark {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+.feature-checkmark svg {
+  width: 20px;
+  height: 20px;
+}
+
+.feature-text {
+  color: #475569;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 1.5;
+}
+
+.choose-plan-button {
+  background: var(--custom-primary, #1976d2);
+  color: var(--shades-white, #fff);
+  border: none;
+  border-radius: 8px;
+  box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   width: 100%;
+  min-height: 56px;
+  margin-top: 28px;
+  padding: 16px;
+  font-family:
+    "Roboto",
+    -apple-system,
+    "Helvetica",
+    sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 1.25px;
+  line-height: 36px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.choose-plan-button:hover {
+  background: #1565c0;
+  transform: translateY(-1px);
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+.choose-plan-button:active {
+  transform: translateY(0);
+  box-shadow: 0px 1px 2px rgba(0, 0, 0, 0.25);
 }
 
 /* Tablet Styles */
 @media (min-width: 768px) {
-  .pricing-cards {
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 20px;
+  .mobile-pricing-container {
+    max-width: 600px;
+    padding: 40px;
   }
 
-  .pricing-card {
-    flex: 1;
-    min-width: 200px;
+  .mobile-pricing-card.detailed {
+    padding: 32px 24px;
   }
 
-  .table-header {
-    justify-content: space-between;
+  .mobile-pricing-card.compact {
+    padding: 24px 32px;
   }
 
-  .plan-labels {
-    gap: 120px;
+  .plan-header {
+    gap: 60px;
   }
 
-  .feature-values {
-    gap: 72px;
+  .plan-level {
+    font-size: 18px;
+  }
+
+  .plan-type {
+    font-size: 15px;
+  }
+
+  .plan-price {
+    font-size: 18px;
+  }
+
+  .plan-description {
+    font-size: 17px;
+    line-height: 28px;
+  }
+
+  .feature-text {
+    font-size: 17px;
   }
 }
 
 /* Desktop Styles */
 @media (min-width: 1024px) {
-  .pricing-container {
-    max-width: 1200px;
-    margin: 0 auto;
+  .mobile-pricing-container {
+    max-width: 800px;
+    padding: 60px;
+    gap: 24px;
   }
 
-  .pricing-cards {
-    flex-wrap: nowrap;
+  .mobile-pricing-card.detailed {
+    padding: 40px 32px;
   }
 
-  .pricing-card {
-    min-width: 200px;
+  .mobile-pricing-card.compact {
+    padding: 32px 40px;
   }
 
-  .header-content {
-    padding: 19px 17px 31px;
+  .plan-header {
+    gap: 80px;
   }
 
-  .main-title {
-    font-size: 28px;
-    line-height: 36px;
-    margin-right: auto;
-    text-align: left;
+  .plan-icon {
+    width: 56px;
+    height: 56px;
   }
 
-  .main-description {
+  .plan-level {
+    font-size: 20px;
+  }
+
+  .plan-type {
+    font-size: 16px;
+  }
+
+  .plan-price {
+    font-size: 20px;
+  }
+
+  .plan-description {
     font-size: 18px;
-    line-height: 28px;
-    margin: 9px auto 0 0;
-    text-align: left;
+    line-height: 30px;
+    margin-top: 24px;
   }
 
-  .feature-row {
+  .features-list {
+    margin-top: 24px;
+    gap: 20px;
   }
 
-  .feature-name {
-    min-width: 150px;
+  .feature-checkmark {
+    width: 24px;
+    height: 24px;
+  }
+
+  .feature-checkmark svg {
+    width: 24px;
+    height: 24px;
+  }
+
+  .feature-text {
+    font-size: 18px;
+  }
+
+  .choose-plan-button {
+    min-height: 64px;
+    margin-top: 32px;
+    font-size: 16px;
   }
 }
 
 /* Large Desktop */
 @media (min-width: 1280px) {
-  .pricing-container {
-    max-width: 1400px;
+  .mobile-pricing-container {
+    max-width: 1000px;
+    padding: 80px;
   }
 
-  .pricing-card {
-    padding: 40px;
+  .mobile-pricing-card.detailed {
+    padding: 48px 40px;
   }
 
-  .feature-table {
-    max-width: 1102px;
-    align-self: end;
+  .mobile-pricing-card.compact {
+    padding: 40px 48px;
+  }
+}
+
+/* Accessibility improvements */
+@media (prefers-reduced-motion: reduce) {
+  .mobile-pricing-card,
+  .choose-plan-button,
+  .dropdown-toggle {
+    transition: none;
+  }
+
+  .mobile-pricing-card:hover {
+    transform: none;
+  }
+
+  .choose-plan-button:hover {
+    transform: none;
+  }
+}
+
+/* Focus styles for keyboard navigation */
+.choose-plan-button:focus,
+.dropdown-toggle:focus {
+  outline: 2px solid #1976d2;
+  outline-offset: 2px;
+}
+
+/* High contrast mode support */
+@media (prefers-contrast: high) {
+  .mobile-pricing-card {
+    border-width: 2px;
+  }
+
+  .feature-checkmark svg circle {
+    fill: #000;
+  }
+
+  .plan-description,
+  .feature-text {
+    color: #000;
   }
 }

--- a/src/pages/PricingComparison.css
+++ b/src/pages/PricingComparison.css
@@ -197,10 +197,10 @@
 
 .plan-labels {
   display: flex;
-  align-items: center;
-  gap: 40px;
-  text-align: center;
-  flex-wrap: wrap;
+  font-weight: 700;
+  width: 100%;
+  justify-content: center;
+  flex-direction: row;
 }
 
 .plan-label {

--- a/src/pages/PricingComparison.css
+++ b/src/pages/PricingComparison.css
@@ -498,11 +498,7 @@
   }
 
   .table-header {
-    justify-content: space-between;
-  }
-
-  .plan-labels {
-    gap: 120px;
+    justify-content: center;
   }
 
   .feature-values {

--- a/src/pages/PricingComparison.css
+++ b/src/pages/PricingComparison.css
@@ -412,17 +412,45 @@
 
 /* Large Desktop */
 @media (min-width: 1280px) {
-  .mobile-pricing-container {
-    max-width: 1000px;
-    padding: 80px;
+  .desktop-table-container {
+    padding: 60px;
+    max-width: 1600px;
   }
 
-  .mobile-pricing-card.detailed {
-    padding: 48px 40px;
+  .pricing-table th,
+  .pricing-table td {
+    padding: 24px;
   }
 
-  .mobile-pricing-card.compact {
-    padding: 40px 48px;
+  .table-plan-icon {
+    width: 56px;
+    height: 56px;
+  }
+
+  .table-plan-level {
+    font-size: 20px;
+  }
+
+  .table-plan-type {
+    font-size: 15px;
+  }
+
+  .table-plan-price {
+    font-size: 18px;
+  }
+
+  .feature-name {
+    font-size: 17px;
+  }
+
+  .feature-value {
+    font-size: 16px;
+  }
+
+  .table-action-button {
+    padding: 14px 28px;
+    font-size: 15px;
+    min-width: 140px;
   }
 }
 

--- a/src/pages/PricingComparison.css
+++ b/src/pages/PricingComparison.css
@@ -254,70 +254,159 @@
 
 /* Desktop Styles */
 @media (min-width: 1024px) {
+  /* Hide mobile cards on desktop */
   .mobile-pricing-container {
-    max-width: 800px;
-    padding: 60px;
-    gap: 24px;
+    display: none;
   }
 
-  .mobile-pricing-card.detailed {
-    padding: 40px 32px;
+  /* Show desktop table on desktop */
+  .desktop-table-container {
+    display: block;
+    padding: 40px;
+    max-width: 1400px;
+    margin: 0 auto;
   }
 
-  .mobile-pricing-card.compact {
-    padding: 32px 40px;
+  .table-wrapper {
+    background-color: #ffffff;
+    border-radius: 16px;
+    border: 1px solid #e2e8f0;
+    box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
   }
 
-  .plan-header {
-    gap: 80px;
+  .pricing-table {
+    width: 100%;
+    border-collapse: collapse;
   }
 
-  .plan-icon {
-    width: 56px;
-    height: 56px;
+  .pricing-table th,
+  .pricing-table td {
+    padding: 20px;
+    text-align: center;
+    border-bottom: 1px solid #f1f5f9;
   }
 
-  .plan-level {
-    font-size: 20px;
+  .pricing-table th {
+    background-color: #f8fafc;
+    font-weight: 600;
+    color: #1f2937;
   }
 
-  .plan-type {
+  .feature-header {
+    text-align: left;
+    font-size: 18px;
+    color: #374151;
+    min-width: 180px;
+  }
+
+  .plan-header-cell {
+    background-color: #f8fafc;
+    border-bottom: 2px solid #e2e8f0;
+    min-width: 200px;
+  }
+
+  .plan-header-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .table-plan-icon {
+    width: 48px;
+    height: 48px;
+  }
+
+  .table-level-icon {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+
+  .table-plan-info {
+    text-align: center;
+  }
+
+  .table-plan-level {
+    font-size: 18px;
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0 0 4px 0;
+  }
+
+  .table-plan-type {
+    font-size: 14px;
+    color: #6b7280;
+    margin: 0 0 8px 0;
+  }
+
+  .table-plan-price {
+    font-size: 16px;
+    font-weight: 600;
+    color: #1f2937;
+    margin: 0;
+  }
+
+  .feature-row:nth-child(even) {
+    background-color: #f9fafb;
+  }
+
+  .feature-name {
+    text-align: left;
+    font-weight: 500;
+    color: #374151;
     font-size: 16px;
   }
 
-  .plan-price {
-    font-size: 20px;
+  .feature-value {
+    color: #1f2937;
+    font-size: 15px;
+    font-weight: 400;
   }
 
-  .plan-description {
-    font-size: 18px;
-    line-height: 30px;
-    margin-top: 24px;
+  .action-row {
+    background-color: #f8fafc;
   }
 
-  .features-list {
-    margin-top: 24px;
-    gap: 20px;
+  .action-row .feature-name {
+    font-weight: 600;
+    color: #1f2937;
   }
 
-  .feature-checkmark {
-    width: 24px;
-    height: 24px;
+  .action-cell {
+    padding: 24px 20px;
   }
 
-  .feature-checkmark svg {
-    width: 24px;
-    height: 24px;
+  .table-action-button {
+    background: #e5e7eb;
+    color: #374151;
+    border: none;
+    border-radius: 8px;
+    padding: 12px 24px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    min-width: 120px;
   }
 
-  .feature-text {
-    font-size: 18px;
+  .table-action-button.primary {
+    background: #1976d2;
+    color: #ffffff;
   }
 
-  .choose-plan-button {
-    min-height: 64px;
-    margin-top: 32px;
-    font-size: 16px;
+  .table-action-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.2);
+  }
+
+  .table-action-button.primary:hover {
+    background: #1565c0;
+  }
+
+  .table-action-button.secondary:hover {
+    background: #d1d5db;
   }
 }
 

--- a/src/pages/PricingComparison.css
+++ b/src/pages/PricingComparison.css
@@ -191,6 +191,8 @@
 
 .feature-label {
   margin-right: auto;
+  width: 179.2px;
+  padding: 0 20px;
 }
 
 .plan-labels {

--- a/src/pages/PricingComparison.css
+++ b/src/pages/PricingComparison.css
@@ -181,12 +181,12 @@
   background-color: rgba(248, 250, 252, 1);
   display: flex;
   width: 100%;
-  align-items: center;
-  gap: 20px;
   font-size: 18px;
   color: rgba(15, 23, 42, 1);
   font-weight: 700;
-  flex-wrap: wrap;
+  justify-content: center;
+  flex-direction: row;
+  align-items: center;
 }
 
 .feature-label {

--- a/src/pages/PricingComparison.css
+++ b/src/pages/PricingComparison.css
@@ -1,4 +1,13 @@
 /* Mobile-first responsive design for pricing component */
+.pricing-wrapper {
+  font-family:
+    "Inter",
+    -apple-system,
+    "Roboto",
+    "Helvetica",
+    sans-serif;
+}
+
 .mobile-pricing-container {
   display: flex;
   flex-direction: column;
@@ -7,12 +16,11 @@
   margin: 0 auto;
   padding: 20px;
   gap: 20px;
-  font-family:
-    "Inter",
-    -apple-system,
-    "Roboto",
-    "Helvetica",
-    sans-serif;
+}
+
+/* Hide desktop table on mobile/tablet */
+.desktop-table-container {
+  display: none;
 }
 
 .mobile-pricing-card {


### PR DESCRIPTION
This change adds a mobile-responsive expandable card layout to the pricing comparison component.

Changes made:
- Added useState hook to manage expanded card state
- Created plans array with pricing data for 5 levels
- Added mobile expandable cards container with toggle functionality
- Implemented responsive design that shows cards on mobile/tablet and table on desktop
- Added comprehensive CSS styling for mobile cards including:
  - Card header with icon, title, and expand toggle
  - Expandable content sections with features and action buttons
  - Hover effects and smooth transitions
  - Accessibility improvements for keyboard navigation and reduced motion
  - High contrast mode support
- Updated existing table styles for better responsive behavior
- Added media queries to hide/show appropriate layouts based on screen size

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/02e71b6255f94307a3960456e61015fb/vortex-nest)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>02e71b6255f94307a3960456e61015fb</projectId>-->
<!--<branchName>vortex-nest</branchName>-->